### PR TITLE
Fixed an issue with whitespace collapsing

### DIFF
--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -5,9 +5,9 @@ get_tmux_option() {
 	local default_value=$2
 	local option_value=$(tmux show-option -gqv "$option")
 	if [ -z "$option_value" ]; then
-		echo $default_value
+		echo "$default_value"
 	else
-		echo $option_value
+		echo "$option_value"
 	fi
 }
 


### PR DESCRIPTION
The padding I wanted
<img width="66" alt="screen shot 2016-07-10 at 7 53 38 pm" src="https://cloud.githubusercontent.com/assets/2068049/16717083/6bdcffd4-46dc-11e6-89ee-899064aec518.png">

Before: whitespace on right side collapsed
<img width="75" alt="screen shot 2016-07-10 at 7 53 05 pm" src="https://cloud.githubusercontent.com/assets/2068049/16717086/78dc9398-46dc-11e6-85f7-846b109db594.png">

After: can add arbitrarily many spaces without collapse
<img width="200" alt="screen shot 2016-07-10 at 8 09 39 pm" src="https://cloud.githubusercontent.com/assets/2068049/16717088/832e0962-46dc-11e6-87f6-2434228dcb22.png">
