### PR TITLE
Add pane_ssh_connected conditional variable

### DIFF
--- a/current_pane_hostname.tmux
+++ b/current_pane_hostname.tmux
@@ -6,8 +6,8 @@ better_hostname="#($CURRENT_DIR/scripts/better_hostname.sh)"
 better_user="#($CURRENT_DIR/scripts/better_user.sh)"
 better_path="#($CURRENT_DIR/scripts/better_path.sh)"
 
-interpolation=('\#H' '\#U')
-script=("#($CURRENT_DIR/scripts/hostname.sh)" "#($CURRENT_DIR/scripts/whoami.sh)")
+interpolation=('\#H' '\#U' '\#\{pane_ssh_connected\}')
+script=("#($CURRENT_DIR/scripts/hostname.sh)" "#($CURRENT_DIR/scripts/whoami.sh)" "#($CURRENT_DIR/scripts/pane_ssh_connected.sh)")
 
 
 source $CURRENT_DIR/scripts/shared.sh

--- a/scripts/pane_ssh_connected.sh
+++ b/scripts/pane_ssh_connected.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $CURRENT_DIR/shared.sh
+
+main() {
+  if ssh_connected; then
+    echo 1
+  fi
+}
+
+main

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -85,13 +85,17 @@ get_remote_info() {
 }
 
 get_info() {
-  # Get current pane command
-  local cmd=$(tmux display-message -p "#{pane_current_command}")
-
   # If command is ssh do some magic
-  if [ $cmd = "ssh" ] || [ $cmd = "sshpass" ]; then
+  if ssh_connected; then
     echo $(get_remote_info $1)
   else
     echo $($1)
   fi
+}
+
+ssh_connected() {
+  # Get current pane command
+  local cmd=$(tmux display-message -p "#{pane_current_command}")
+
+  [ $cmd = "ssh" ] || [ $cmd = "sshpass" ]
 }


### PR DESCRIPTION
The variable can be used in tmux's status bar like so:
"#{pane_ssh_connected}"
This will print 1 if the currently selected pane has an active ssh
connection, allowing further constructs like
"#{?#{pane_ssh_connected},ssh,no-ssh}", which evaluates to "ssh" if the
currently selected pane has an active ssh connection and to "no-ssh"
otherwise.