### PR TITLE
add: ssh port variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Replaces the `#H` format and adds a `#U` format option.
 
 - `#H` will be the hostname of your current path. If there is an ssh session opened, the ssh hostname will show instead of the local one.
 - `#U` will show the `whoami` result or the user that logged in an ssh session.
+- `#{pane_ssh_port}` if an open ssh session will show the connection port, otherwise it will be empty.
 - `#{pane_ssh_connected}` will be set to 1 if the currently selected pane has an active ssh connection. (Useful for `#{?#{pane_ssh_connection},ssh,no-ssh}` which will evaluate to `ssh` if there is an active ssh in the currently selected pane and `no-ssh` otherwise.)
 
 Here's the example in `.tmux.conf`:

--- a/current_pane_hostname.tmux
+++ b/current_pane_hostname.tmux
@@ -6,23 +6,22 @@ better_hostname="#($CURRENT_DIR/scripts/better_hostname.sh)"
 better_user="#($CURRENT_DIR/scripts/better_user.sh)"
 better_path="#($CURRENT_DIR/scripts/better_path.sh)"
 
-interpolation=('\#H' '\#U' '\#\{pane_ssh_connected\}')
-script=("#($CURRENT_DIR/scripts/hostname.sh)" "#($CURRENT_DIR/scripts/whoami.sh)" "#($CURRENT_DIR/scripts/pane_ssh_connected.sh)")
+interpolation=('\#H' '\#U' '\#\{pane_ssh_port\}' '\#\{pane_ssh_connected\}')
+script=("#($CURRENT_DIR/scripts/hostname.sh)" "#($CURRENT_DIR/scripts/whoami.sh)" "#($CURRENT_DIR/scripts/port.sh)" "#($CURRENT_DIR/scripts/pane_ssh_connected.sh)")
 
 
 source $CURRENT_DIR/scripts/shared.sh
 
 do_interpolation() {
-        local interpolated=$1
-        local j=0
+    local interpolated=$1
+    local j=0
 
-        for i in "${interpolation[@]}"; do
-          local s=${script[$j]}
-          local interpolated=${interpolated/$i/$s}
-          ((j+=1))
-        done
-
-	echo "$interpolated"
+    for i in "${interpolation[@]}"; do
+        local s=${script[$j]}
+        local interpolated=${interpolated//$i/$s}
+        ((j+=1))
+    done
+    echo "$interpolated"
 }
 
 update_tmux_option() {

--- a/scripts/port.sh
+++ b/scripts/port.sh
@@ -6,9 +6,7 @@ source $CURRENT_DIR/shared.sh
 
 main() {
   if ssh_connected; then
-      echo 1
-  else
-      echo 0
+      get_info "port"
   fi
 }
 

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -19,7 +19,7 @@ set_tmux_option() {
 
 parse_ssh_port() {
   # If there is a port get it
-  local port=$(echo $1|grep -Eo '\-p ([0-9]+)'|sed 's/-p //')
+  local port=$(echo $1|grep -Eo '\-p\s*([0-9]+)'|sed 's/-p\s*//')
 
   if [ -z $port ]; then
     local port=22
@@ -62,8 +62,7 @@ get_remote_info() {
 
   local port=$(parse_ssh_port "$cmd")
 
-  local cmd=$(echo $cmd|sed 's/\-p '"$port"'//g')
-
+  local cmd=$(echo $cmd|sed 's/\-p\s*'"$port"'//g')
   local user=$(echo $cmd | awk '{print $NF}'|cut -f1 -d@)
   local host=$(echo $cmd | awk '{print $NF}'|cut -f2 -d@)
 
@@ -77,6 +76,9 @@ get_remote_info() {
       ;;
     "hostname")
       echo $host
+      ;;
+    "port")
+      echo $port
       ;;
     *)
       echo "$user@$host:$port"


### PR DESCRIPTION
fix: variable reused (like #{?#{pane_ssh_connected}, #U(#H:#{pane_ssh_port}), #U(local)})
fix: ssh_connected returns value for condition (returns 1 or 0)
fix: ssh port syntax options (-p22/-p 22)