### PR TITLE
Add short hostname format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Replaces the `#H` format and adds a `#U` format option.
 ### Usage
 
 - `#H` will be the hostname of your current path. If there is an ssh session opened, the ssh hostname will show instead of the local one.
+- `#{hostname_short}` will be the short hostname of your current path (up to the first dot). If there is an ssh session opened, the ssh hostname will show instead of the local one.
 - `#U` will show the `whoami` result or the user that logged in an ssh session.
 - `#{pane_ssh_port}` if an open ssh session will show the connection port, otherwise it will be empty.
 - `#{pane_ssh_connected}` will be set to 1 if the currently selected pane has an active ssh connection. (Useful for `#{?#{pane_ssh_connection},ssh,no-ssh}` which will evaluate to `ssh` if there is an active ssh in the currently selected pane and `no-ssh` otherwise.)

--- a/current_pane_hostname.tmux
+++ b/current_pane_hostname.tmux
@@ -2,8 +2,8 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-interpolation=('\#H' '\#U' '\#\{pane_ssh_port\}' '\#\{pane_ssh_connected\}')
-script=("#($CURRENT_DIR/scripts/hostname.sh)" "#($CURRENT_DIR/scripts/whoami.sh)" "#($CURRENT_DIR/scripts/port.sh)" "#($CURRENT_DIR/scripts/pane_ssh_connected.sh)")
+interpolation=('\#H' '\#{hostname_short}' '\#U' '\#\{pane_ssh_port\}' '\#\{pane_ssh_connected\}')
+script=("#($CURRENT_DIR/scripts/hostname.sh)" "#($CURRENT_DIR/scripts/hostname_short.sh)" "#($CURRENT_DIR/scripts/whoami.sh)" "#($CURRENT_DIR/scripts/port.sh)" "#($CURRENT_DIR/scripts/pane_ssh_connected.sh)")
 
 
 source $CURRENT_DIR/scripts/shared.sh

--- a/scripts/hostname_short.sh
+++ b/scripts/hostname_short.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $CURRENT_DIR/shared.sh
+
+main() {
+  get_info "hostname -s"
+}
+
+main


### PR DESCRIPTION
In many cases the full hostname is too long. `hostname -s` returns the hostname up to the first dot. I've added `#{hostname_short}` formatting option to use just that.