### PR TITLE
Plugin rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,50 @@
 
 Tmux plugin that enables displaying hostname and user of the current pane in your status bar.
 
-Replaces the `#H` format and adds a `#U` format option.
+> [!IMPORTANT]
+> Replaces the `#H` default format variable
 
-### Usage
+## Usage
 
-- `#H` (`#{hostname}`) will be the hostname of your current path. If there is an ssh session opened, the ssh hostname will show instead of the local one.
-- `#{hostname_short}` will be the short hostname of your current path (up to the first dot). If there is an ssh session opened, the ssh hostname will show instead of the local one.
-- `#U` (`#{username}`) will show the `whoami` result or the user that logged in an ssh session.
-- `#{pane_ssh_port}` if an open ssh session will show the connection port, otherwise it will be empty.
-- `#{pane_ssh_connected}` will be set to 1 if the currently selected pane has an active ssh connection. (Useful for `#{?#{pane_ssh_connected},ssh,no-ssh}` which will evaluate to `ssh` if there is an active ssh in the currently selected pane and `no-ssh` otherwise.)
-- `#{pane_ssh_connect}` if an open ssh session will show the connection info in `"username@hostname:port"` format, otherwise it will be empty.
+### Basics
 
-Here's the example in `.tmux.conf`:
+- `#H` (`#{hostname}`) will be the hostname of your current path
+- `#{hostname_short}` will be the short hostname of your current path (up to the first dot)
+- `#U` (`#{username}`) will be current user name
 
-```bash
-set -g status-right '#[fg=cyan,bold] #U@#H #[default]#[fg=blue]#(tmux display-message -p "#{pane_current_path}" | sed "s#$HOME#~#g") #[fg=red]%H:%M %d-%b-%y#[default]'
+### Remote connection info
+
+Plugin can detect pane has remote shell connection in several states:
+- ssh session inside pane
+- running docker (or podman) container
+
+In both cases, `#{hostname}` and `#{username}` with show their values relatively to that state.
+
+Besides `#{hostname}` and `#{username}` there are more usefull format variables:
+
+- `#{pane_ssh_port}` will show the connection port, otherwise it will be empty.
+- `#{pane_ssh_connected}` will be set to 1 if the currently selected pane has an active connection. (Useful for `#{?#{pane_ssh_connected},ssh,no-ssh}` which will evaluate to `ssh` if there is an active remote session in the currently selected pane and `no-ssh` otherwise.)
+- `#{pane_ssh_connect}` if an open remote session exists will show the connection info in `"username@hostname:port"` format, otherwise it will be empty.
+
+### Example
+
+```tmux
+set -g status-left " #[bg=blue]#U#[bg=red]@#H#{?#{pane_ssh_port},:#{pane_ssh_port},}#[default] "
 ```
 
-### Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
+## Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
 Add plugin to the list of TPM plugins in `.tmux.conf`:
 
-    set -g @tpm_plugins "                 \
-      tmux-plugins/tpm                    \
-      soyuka/tmux-current-pane-hostname     \
-    "
+```tmux
+set -g @plugin "soyuka/tmux-current-pane-hostname"
+```
 
 Hit `prefix + I` to fetch the plugin and source it.
 
 `#U@#H` interpolation should now take the current pane ssh status into consideration.
 
-### Manual Installation
+## Manual Installation
 
 Clone the repo:
 
@@ -49,16 +62,14 @@ Reload TMUX environment:
 
 `#U@#H` interpolation should now work.
 
-### Limitations
+## Todo
 
-I wanted to get the current path of the opened ssh session but that's not possible. I haven't found a way to get the output of a remote command that will be executed on an opened ssh session. A dirty way would be to use `send-keys pwd Enter` but this will show on the pane and we don't want this.
-So, I'm just getting the correct ssh command corresponding to the pane job pid and parsing it, for example:
-```
-ssh test@host.com
-# #H => host.com
-# #U => test
-```
+- implement templating for `#{pane_ssh_connect}`
 
-### License
+## Limitations
+
+- only named running container may be defined, otherwise it would be ignored
+
+## License
 
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ Replaces the `#H` format and adds a `#U` format option.
 
 ### Usage
 
-- `#H` will be the hostname of your current path. If there is an ssh session opened, the ssh hostname will show instead of the local one.
+- `#H` (`#{hostname}`) will be the hostname of your current path. If there is an ssh session opened, the ssh hostname will show instead of the local one.
 - `#{hostname_short}` will be the short hostname of your current path (up to the first dot). If there is an ssh session opened, the ssh hostname will show instead of the local one.
-- `#U` will show the `whoami` result or the user that logged in an ssh session.
+- `#U` (`#{username}`) will show the `whoami` result or the user that logged in an ssh session.
 - `#{pane_ssh_port}` if an open ssh session will show the connection port, otherwise it will be empty.
 - `#{pane_ssh_connected}` will be set to 1 if the currently selected pane has an active ssh connection. (Useful for `#{?#{pane_ssh_connected},ssh,no-ssh}` which will evaluate to `ssh` if there is an active ssh in the currently selected pane and `no-ssh` otherwise.)
+- `#{pane_ssh_connect}` if an open ssh session will show the connection info in `"username@hostname:port"` format, otherwise it will be empty.
 
 Here's the example in `.tmux.conf`:
 

--- a/current_pane_hostname.tmux
+++ b/current_pane_hostname.tmux
@@ -16,7 +16,7 @@ placeholders_to_scripts=(
 	"\#\{pane_ssh_connect\}//#($CURRENT_DIR/scripts/pane_ssh_connect.sh)")
 
 
-source $CURRENT_DIR/scripts/shared.sh
+source $CURRENT_DIR/scripts/utils/tmux.sh
 
 do_interpolation() {
 	local interpolated=$1

--- a/scripts/host.sh
+++ b/scripts/host.sh
@@ -5,7 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $CURRENT_DIR/shared.sh
 
 main() {
-  get_info "whoami"
+	get_info host
 }
 
 main

--- a/scripts/host_short.sh
+++ b/scripts/host_short.sh
@@ -5,7 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $CURRENT_DIR/shared.sh
 
 main() {
-	get_info port
+	get_info host_short
 }
 
 main

--- a/scripts/pane_ssh_connect.sh
+++ b/scripts/pane_ssh_connect.sh
@@ -2,10 +2,21 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+source $CURRENT_DIR/utils/tmux.sh
 source $CURRENT_DIR/shared.sh
 
 main() {
-	get_info
+	local user host port
+	IFS='#' read -r user host port <<< "$(get_info)"
+	echo "${user}${host:+@$host}${port:+:$port}"
+
+	# @TODO user-formatted pane_ssh_connect output
+	# eval is literaly evil, so i won't use this
+	# eval echo $(get_tmux_option $pane_ssh_connect_format)
+	# get_tmux_option $pane_ssh_connect_format | sed \
+	# 	-e "s/%{user}/$user/" \
+	# 	-e "s/%{host}/$host/" \
+	# 	-e "s/%{port}/$port/"
 }
 
 main

--- a/scripts/pane_ssh_connect.sh
+++ b/scripts/pane_ssh_connect.sh
@@ -5,7 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $CURRENT_DIR/shared.sh
 
 main() {
-  get_info "hostname -s"
+	get_info
 }
 
 main

--- a/scripts/pane_ssh_connected.sh
+++ b/scripts/pane_ssh_connected.sh
@@ -5,11 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $CURRENT_DIR/shared.sh
 
 main() {
-  if ssh_connected; then
-      echo 1
-  else
-      echo 0
-  fi
+	ssh_connected && echo 1 || echo 0
 }
 
 main

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -17,7 +17,7 @@ get_remote_info() {
 	# First get the current pane command pid to get the full command with arguments
 	local cmd=$(_current_pane_command | grep -E 'ssh' | sed -E 's/^[0-9]*[[:blank:]]*ssh //')
 	# Fetch configuration with given cmd
-	ssh -G $cmd 2>/dev/null | grep -E -e '^host\s' -e '^port\s' -e '^user\s' | sort | cut -f 2 -d ' ' | xargs
+	ssh -G $cmd 2>/dev/null | grep -E -e '^hostname\s' -e '^port\s' -e '^user\s' | sort | cut -f 2 -d ' ' | xargs
 }
 
 get_container_info() {
@@ -84,9 +84,9 @@ containered() {
 
 _current_pane_command() {
 	local pane_pid=$(tmux display-message -p "#{pane_pid}")
+	local pane_process_pid=$(pgrep -flaP $pane_pid | cut -f 1 -d ' ')
 
-	# @TODO research, maybe `pgrep -flaP $pane_pid` is enough
-	{ pgrep -flaP $pane_pid; ps -o command -p $pane_pid; } | xargs -I{} echo {}
+	ps -o command -p $pane_process_pid | grep -v 'COMMAND'
 }
 
 _get_username() {

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -14,30 +14,52 @@ set_tmux_option() {
 }
 
 get_remote_info() {
-	local command=$1
-	local pane_pid=$(tmux display-message -p "#{pane_pid}")
-
 	# First get the current pane command pid to get the full command with arguments
-	local cmd=$({ pgrep -flaP $pane_pid ; ps -o command -p $pane_pid ; } | xargs -I{} echo {} | grep ssh | sed -E 's/^[0-9]*[[:blank:]]*ssh //')
+	local cmd=$(_current_pane_command | grep -E 'ssh' | sed -E 's/^[0-9]*[[:blank:]]*ssh //')
 	# Fetch configuration with given cmd
 	ssh -G $cmd 2>/dev/null | grep -E -e '^host\s' -e '^port\s' -e '^user\s' | sort | cut -f 2 -d ' ' | xargs
 }
 
+get_container_info() {
+	local cmd=$(_current_pane_command | grep -E 'docker|podman' | sed -E 's/^[0-9]*[[:blank:]]* //')
+
+	local runner=${cmd%% *}
+	if [[ $cmd =~ ' --name' ]]; then
+		local container=$(echo ${cmd##* --name} | cut -f 1 -d ' ')
+		container=${container##*=}
+	else
+		# @TODO get dynamic named container
+		# local all_running_containers=$($runner ps -q | xargs $runner inspect)
+		return
+	fi
+
+	local info=$($runner inspect --format '{{ .Config.Hostname }}/{{ .Config.Domainname }}/{{ .Config.User }}' $container)
+	local host=$(echo $info | cut -f 1 -d '/')
+	local domain=$(echo $info | cut -f 2 -d '/')
+	local user=$(echo $info | cut -f 3 -d '/')
+	# @TODO `port` is not applicable with container for now
+	echo "${host}${domain:+.$domain} 0 ${user}"
+}
+
 get_info() {
+	local host port user
 	# If command is ssh, fetch connection info
 	if ssh_connected; then
 		read -r host port user <<<$(get_remote_info)
 	fi
+	if containered; then
+		read -r host port user <<<$(get_container_info)
+	fi
 	# Return requested info
 	case "$1" in
 		"user") # user from ssh info or `whoami`
-			[[ -z "$user" ]] && whoami || echo "$user"
+			[[ -z "$user" ]] && _get_username || echo "$user"
 			;;
 		"host") # host from ssh info or `hostname`
-			[[ -z "$host" ]] && hostname || echo "$host"
+			[[ -z "$host" ]] && _get_hostname || echo "$host"
 			;;
 		"host_short") # host from ssh info or `hostname -s`
-			[[ -z "$host" ]] && hostname -s || echo "$host"
+			[[ -z "$host" ]] && _get_hostname_short || echo "$host"
 			;;
 		"port") # port from ssh info or empty
 			echo "$port"
@@ -49,10 +71,32 @@ get_info() {
 }
 
 ssh_connected() {
-	local pane_pid=$(tmux display-message -p "#{pane_pid}")
-
-	# Get current pane command
-	local cmd=$(pgrep -flaP $pane_pid)
+	local cmd=$(_current_pane_command)
 
 	[[ $cmd =~ " ssh " ]] || [[ $cmd =~ " sshpass " ]]
+}
+
+containered() {
+	local cmd=$(_current_pane_command)
+
+	[[ $cmd =~ " docker " ]] || [[ $cmd =~ " podman " ]]
+}
+
+_current_pane_command() {
+	local pane_pid=$(tmux display-message -p "#{pane_pid}")
+
+	# @TODO research, maybe `pgrep -flaP $pane_pid` is enough
+	{ pgrep -flaP $pane_pid; ps -o command -p $pane_pid; } | xargs -I{} echo {}
+}
+
+_get_username() {
+	command -v whoami && whoami
+}
+
+_get_hostname() {
+	command -v hostname && hostname || echo "${HOSTNAME}"
+}
+
+_get_hostname_short() {
+	command -v hostname && hostname --short || echo "${HOSTNAME%%.*}"
 }

--- a/scripts/user.sh
+++ b/scripts/user.sh
@@ -5,7 +5,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $CURRENT_DIR/shared.sh
 
 main() {
-  get_info "hostname"
+	get_info user
 }
 
 main

--- a/scripts/utils/tmux.sh
+++ b/scripts/utils/tmux.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# @TODO user-formatted pane_ssh_connect output
+declare -r pane_ssh_connect_format='@pane-ssh-connect-format'
+
+get_tmux_option() {
+	local option=$1
+	local default_value=$2
+	local option_value=$(tmux show-option -gqv "$option")
+	[[ -z "$option_value" ]] && echo "$default_value" || echo "$option_value"
+}
+
+set_tmux_option() {
+	local option=$1
+	local value=$2
+	tmux set-option -gq "$option" "$value"
+}
+


### PR DESCRIPTION
# Changes:

## Common refactoring

Better code encapsulation, less dependencies (e.g. `pgrep` no more needed)

## New placeholders for `tmux.conf`

Added `#{hostname}` and `#{username}` as aliases for `#{H}` and `{#U}` respectively, added `#{pane_ssh_connect}` as all-in-one solution

## Better ssh support

Now, plugin uses native `ssh -G` functionality, to fetch actual remote connection configuration (even on ad-hoc connection, like when `host` is not specified inside `~/.ssh/config`)

## Nested ssh support

Now, plugin can detect interactive ssh session even if it was spawn by another process (e.g. `podman machine ssh <vm_name>` or `limactl shell <vm_name>`)

## Running containers support

Now, plugin can detect if pane is attached to named running podman or docker container (e.g. `podman run --name my-app --tty --interactive ...`) and shows it's user, hostname and domain

